### PR TITLE
Fix recursion in TaskResult serialization

### DIFF
--- a/backend/src/main/java/com/ogame/automation/entity/TaskResult.java
+++ b/backend/src/main/java/com/ogame/automation/entity/TaskResult.java
@@ -2,6 +2,7 @@ package com.ogame.automation.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 
 import java.time.LocalDateTime;
 
@@ -16,6 +17,7 @@ public class TaskResult {
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "task_id", nullable = false)
+    @JsonBackReference("task-results")
     private Task task;
 
     @NotNull


### PR DESCRIPTION
## Summary
- prevent infinite recursion when serializing TaskResult

## Testing
- `./mvnw test` *(fails: JAVA_HOME is not defined correctly)*

------
https://chatgpt.com/codex/tasks/task_e_686240d766a883218083cdba0e2b08b0