### PR TITLE
Configure Angular proxy for local dev

### DIFF
--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -4,7 +4,8 @@ Run locally:
 ```bash
 cd frontend
 npm install
-ng serve
+npm start
+# or: ng serve --proxy-config proxy.conf.json
 ```
 Open `http://localhost:4200`
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --proxy-config proxy.conf.json",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false
+  }
+}


### PR DESCRIPTION
## Summary
- add proxy.conf.json for Angular API proxying
- update frontend start script to use the proxy config
- explain the proxy usage in frontend docs

## Testing
- `./mvnw test` *(fails: JAVA_HOME not set)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f5117338832185bdb5af6ce39142